### PR TITLE
Add functionality to delete mini covers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -92,7 +92,6 @@ function randomizeCover() {
 
 function createUserCover() {
   currentCover = new Cover(covers[0], titles[0], descriptors[1], descriptors[0]);
-
 }
 
 function seeUserBook(event) {
@@ -118,7 +117,6 @@ function saveUserInput() {
   titles.unshift(document.getElementById('title').value);
   descriptors.unshift(document.getElementById('descriptor1').value);
   descriptors.unshift(document.getElementById('descriptor2').value);
-
 }
 
 function saveUserFavorite(){

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ var coverImg = document.querySelector('img');
 var coverTitle = document.querySelector('.cover-title');
 var tagline1 = document.querySelector('.tagline-1');
 var tagline2 = document.querySelector('.tagline-2');
+var miniCovers = document.querySelector('.mini-covers')
 // page view sections
 var mainCoverSection = document.querySelector('.main-cover')
 var formSection = document.querySelector('.form-view');
@@ -27,8 +28,9 @@ saveCoverButton.addEventListener('click', saveUserFavorite);
 viewSavedButton.addEventListener('click', viewSavedPage);
 customBookButton.addEventListener('click', viewFormPage);
 makeMyBook.addEventListener('click', seeUserBook);
-// event handlers and other functions
-window.onload = randomizeCover;    //window onload
+savedCoversGallery.addEventListener('dblclick', deleteCover);
+
+window.onload = randomizeCover;
 // page views
 function injectCoverData(){
   coverImg.src = currentCover.cover;
@@ -45,7 +47,7 @@ function goHome() {
   formSection.classList.add('hidden');
   saveCoverButton.classList.remove('hidden');
   savedCoversGallery.classList.add('hidden');
-};
+}
 
 function viewFormPage() {
   savedCoversGallery.innerHTML = `<br />`;
@@ -69,18 +71,23 @@ function viewSavedPage() {
 }
 
 function injectCoverGallery() {
-  savedCoversGallery.innerHTML = `<br />`;
-for (i = 0; i < savedCovers.length; i++){
-  savedCoversGallery.innerHTML += `<div class="mini-cover"><img class="mini-cover" src="${savedCovers[i].cover}">
-  <p class="cover-title">${savedCovers[i].title}</p>
-  <h3 class="tagline">A tale of <span class="tagline-1">${savedCovers[i].tagline1}</span> and <span class="tagline-2">${savedCovers[i].tagline2}</span></h3></div>`;
+  savedCoversGallery.innerHTML = '';
+for (i = 0; i < savedCovers.length; i++) {
+  savedCoversGallery.innerHTML +=
+  `<div class="mini-cover">
+    <img class="mini-cover" src="${savedCovers[i].cover}" id= "${savedCovers[i].id}">
+    <p class="cover-title">${savedCovers[i].title}</p>
+    <h3 class="tagline">A tale of
+    <span class="tagline-1">${savedCovers[i].tagline1}</span> and
+    <span class="tagline-2">${savedCovers[i].tagline2}</span>
+  </h3></div>`;
   }
 }
 //cover creators
 function randomizeCover() {
   currentCover = new Cover(covers[getRandomIndex(covers)], titles[getRandomIndex(titles)], descriptors[getRandomIndex(descriptors)], descriptors[getRandomIndex(descriptors)]);
 
-  injectCoverData()
+  injectCoverData();
 }
 
 function createUserCover() {
@@ -90,12 +97,22 @@ function createUserCover() {
 
 function seeUserBook(event) {
   event.preventDefault();
-  saveUserInput ();
+  saveUserInput();
   createUserCover();
   injectCoverData();
   goHome();
 }
-//data
+
+function deleteCover(event) {
+  var deleteId = parseInt(event.target.id);
+  for (i = 0; i < savedCovers.length; i++){
+    if (deleteId === savedCovers[i].id) {
+      savedCovers.splice(i, 1);
+    }
+  }
+  injectCoverGallery();
+}
+
 function saveUserInput() {
   covers.unshift(document.getElementById('cover').value);
   titles.unshift(document.getElementById('title').value);
@@ -109,7 +126,6 @@ if (savedCovers.includes(currentCover)){
   } else {
     savedCovers.push(currentCover)
   }
-  console.log(savedCovers)
 };
 
 function getRandomIndex(array) {


### PR DESCRIPTION
Greyson,

We created a variable that we assigned to the saved covers element and created an event listener that expected a double click to delete a specific mini-cover using the id#. We realized that when replacing the current cover with the newly created cover we were not assigning the id property to the newly created cover, making it difficult to find the id#. Thanks for helping me to better understand these concepts.